### PR TITLE
Implement store flag_updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,9 @@ jobs:
       options: --privileged
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        # If your submodules are configured to use SSH instead of HTTPS please uncomment the following line
-        git config --global url."https://github.com/".insteadOf "git@github.com:"
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      uses: actions/checkout@v3
+      with:
+        submodules: 'true'
     - name: Build
       uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
       with:

--- a/src/controllers/application.rs
+++ b/src/controllers/application.rs
@@ -48,6 +48,7 @@ pub enum ApplicationMessage {
     },
     NewMessages {
         new_messages: Vec<models::NewMessage>,
+        folder: models::Folder,
         identity: Arc<models::Identity>,
     },
     OpenGoogleAuthentication {
@@ -341,7 +342,11 @@ impl Application {
                             }),
                     );
                 }
-                ApplicationMessage::NewMessages { new_messages, identity } => {
+                ApplicationMessage::NewMessages {
+                    new_messages,
+                    folder,
+                    identity,
+                } => {
                     info!(
                         "New messages received for {}: {}",
                         identity.bare_identity.email_address,

--- a/src/controllers/application.rs
+++ b/src/controllers/application.rs
@@ -353,6 +353,10 @@ impl Application {
                         new_messages.len()
                     );
 
+                    let conversations_list_model_clone = conversations_list_model_clone.clone();
+
+                    conversations_list_model_clone.handle_new_messages_for_folder(&folder);
+
                     for new_message in new_messages {
                         info!("New message {} ", new_message.subject)
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(hash_drain_filter)]
+
 #[macro_use]
 extern crate serde_derive;
 
@@ -7,10 +9,10 @@ extern crate diesel;
 #[macro_use]
 extern crate diesel_migrations;
 
+mod backends;
 mod bindings;
 mod controllers;
 mod google_oauth;
-mod backends;
 mod litehtml_callbacks;
 mod models;
 mod schema;

--- a/src/models/database.rs
+++ b/src/models/database.rs
@@ -126,7 +126,7 @@ impl MessageSummary {
     }
 }
 
-#[derive(AsChangeset, Debug)]
+#[derive(AsChangeset, Debug, Clone)]
 #[table_name = "messages"]
 pub struct MessageFlags {
     pub seen: bool,

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -304,6 +304,8 @@ impl Identity {
                 uid_validity: current_uid_validity,
             } => {
                 if new_uid_validity == current_uid_validity {
+                    debug!("UID validity match");
+
                     flag_updates.map(|flag_updates| {
                         self.store.store_message_flag_updates_for_folder(&flag_updates);
 
@@ -316,6 +318,8 @@ impl Identity {
                     // This needs to happen before the call to "Keep only uids for folder"
                     self.store.store_messages_for_folder(&mut new_messages, folder, None)?;
                 } else {
+                    debug!("UID validity mismatch");
+
                     //@TODO delete all mail
                     //@todo store
                     //@TODO set new uid_validity on folder

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -349,7 +349,7 @@ impl Identity {
         let new_messages = match backend_sync_type {
             imap::SyncType::Fresh => {
                 self.store
-                    .store_messages_for_folder(&mut new_messages, folder, Some(new_uid_validity))?;
+                    .store_messages_for_folder(&mut new_messages, folder, services::StoreType::Fresh { new_uid_validity })?;
 
                 None
             }
@@ -370,15 +370,16 @@ impl Identity {
                     });
 
                     // This needs to happen before the call to "Keep only uids for folder"
-                    self.store.store_messages_for_folder(&mut new_messages, folder, None)?;
+                    self.store
+                        .store_messages_for_folder(&mut new_messages, folder, services::StoreType::Incremental)?;
 
                     Some(new_messages)
                 } else {
                     debug!("UID validity mismatch");
 
-                    //@TODO delete all mail
-                    //@todo store
-                    //@TODO set new uid_validity on folder
+                    self.store
+                        .store_messages_for_folder(&mut new_messages, folder, services::StoreType::Fresh { new_uid_validity })?;
+
                     None
                 }
             }

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -111,7 +111,7 @@ impl Identity {
 
         self.clone().handle_sync_messages_for_folder_result(&inbox_folder, sync_result);
 
-        self.clone().sync_non_inbox_folders().await.map_err(|e| {
+        self.clone().sync_messages_for_non_inbox_folders().await.map_err(|e| {
             //@TODO show in UI
             error!("{}", e);
         });
@@ -137,7 +137,7 @@ impl Identity {
                         error!("{}", e);
                     });
 
-                    self.clone().sync_non_inbox_folders().await.map_err(|e| {
+                    self.clone().sync_messages_for_non_inbox_folders().await.map_err(|e| {
                         //@TODO show in UI
                         error!("{}", e);
                     });
@@ -150,7 +150,7 @@ impl Identity {
         }
     }
 
-    async fn sync_non_inbox_folders(self: Arc<Self>) -> Result<(), String> {
+    async fn sync_messages_for_non_inbox_folders(self: Arc<Self>) -> Result<(), String> {
         let folders = self.store.get_folders(&self.bare_identity)?;
 
         for folder in folders.iter().filter(|x| x.folder_name != "INBOX") {

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -360,14 +360,17 @@ impl Identity {
                 if new_uid_validity == current_uid_validity {
                     debug!("UID validity match");
 
-                    flag_updates.map(|flag_updates| {
-                        self.store.store_message_flag_updates_for_folder(&flag_updates);
+                    match flag_updates {
+                        Some(flag_updates) => {
+                            self.store.store_message_flag_updates_for_folder(&flag_updates)?;
 
-                        // We use this to filter out expunged messages, but we need to run this before
-                        // storing new messages. Otherwise we'll just delete the newly added messages
-                        self.store
-                            .keep_only_uids_for_folder(&flag_updates.iter().map(|x| x.uid).collect::<_>(), folder);
-                    });
+                            // We use this to filter out expunged messages, but we need to run this before
+                            // storing new messages. Otherwise we'll just delete the newly added messages
+                            self.store
+                                .keep_only_uids_for_folder(&flag_updates.iter().map(|x| x.uid).collect::<_>(), folder)?;
+                        }
+                        None => {}
+                    };
 
                     // This needs to happen before the call to "Keep only uids for folder"
                     self.store

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -80,10 +80,6 @@ impl Identity {
         self.clone().sync_folders().await?;
 
         for folder in self.store.get_folders(&self.bare_identity)? {
-            if folder.folder_name != "INBOX" {
-                continue;
-            }
-
             self.clone().sync_messages_for_folder(&folder, SyncType::Fresh).await?;
         }
 

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -92,6 +92,12 @@ impl Identity {
     }
 
     pub async fn start_session(self: Arc<Self>) {
+        info!("Syncing folders");
+        self.clone().sync_folders().await.map_err(|e| {
+            //@TODO show in UI
+            error!("{}", e);
+        });
+
         let inbox_folder = self
             .store
             .get_folders(&self.bare_identity)
@@ -100,12 +106,6 @@ impl Identity {
             .find(|&x| x.folder_name == "INBOX")
             .unwrap()
             .clone();
-
-        info!("Syncing folders");
-        self.clone().sync_folders().await.map_err(|e| {
-            //@TODO show in UI
-            error!("{}", e);
-        });
 
         info!("Syncing messages");
 

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -94,6 +94,8 @@ impl Identity {
             error!("{}", e);
         });
 
+        // @TODO if sync_folders failed twice (init and start_session), then there can
+        // be no INBOX folder
         let inbox_folder = self
             .store
             .get_folders(&self.bare_identity)

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -306,12 +306,10 @@ impl Identity {
                 if new_uid_validity == current_uid_validity {
                     self.store.store_messages_for_folder(&mut new_messages, folder, None)?;
 
-                    if let Some(flag_updates) = flag_updates {
-                        //@TODO
-                        for flag_update in flag_updates.iter() {
-                            debug!("{}", flag_update.uid);
-                        }
-                    }
+                    flag_updates
+                        .map(|flag_updates| self.store.store_message_flag_updates_for_folder(&flag_updates))
+                        .transpose()?;
+
                     //@TODO 2) find out which old messages got expunged; and
                 } else {
                     //@TODO delete all mail

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -306,11 +306,12 @@ impl Identity {
                 if new_uid_validity == current_uid_validity {
                     self.store.store_messages_for_folder(&mut new_messages, folder, None)?;
 
-                    flag_updates
-                        .map(|flag_updates| self.store.store_message_flag_updates_for_folder(&flag_updates))
-                        .transpose()?;
+                    flag_updates.map(|flag_updates| {
+                        self.store.store_message_flag_updates_for_folder(&flag_updates);
 
-                    //@TODO 2) find out which old messages got expunged; and
+                        self.store
+                            .keep_only_uids_for_folder(&flag_updates.iter().map(|x| x.uid).collect::<_>(), folder);
+                    });
                 } else {
                     //@TODO delete all mail
                     //@todo store

--- a/src/models/identity.rs
+++ b/src/models/identity.rs
@@ -304,14 +304,17 @@ impl Identity {
                 uid_validity: current_uid_validity,
             } => {
                 if new_uid_validity == current_uid_validity {
-                    self.store.store_messages_for_folder(&mut new_messages, folder, None)?;
-
                     flag_updates.map(|flag_updates| {
                         self.store.store_message_flag_updates_for_folder(&flag_updates);
 
+                        // We use this to filter out expunged messages, but we need to run this before
+                        // storing new messages. Otherwise we'll just delete the newly added messages
                         self.store
                             .keep_only_uids_for_folder(&flag_updates.iter().map(|x| x.uid).collect::<_>(), folder);
                     });
+
+                    // This needs to happen before the call to "Keep only uids for folder"
+                    self.store.store_messages_for_folder(&mut new_messages, folder, None)?;
                 } else {
                     //@TODO delete all mail
                     //@todo store

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,3 +3,4 @@ mod store;
 
 pub use authorization_code_receiver::AuthorizationCodeReceiver;
 pub use store::Store;
+pub use store::StoreType;

--- a/src/services/store.rs
+++ b/src/services/store.rs
@@ -332,7 +332,7 @@ impl Store {
                 for flag_update in flag_updates.iter() {
                     diesel::update(schema::messages::table)
                         .filter(schema::messages::uid.eq(flag_update.uid as i64))
-                        .set(flag_update.flags)
+                        .set(flag_update.flags.clone())
                         .execute(&connection)?;
                 }
 


### PR DESCRIPTION
Closes #218
Closes #82

- [x] Implement expunge updates
- [x] Always send `NewMessage` updates
- [x] Update on uid_validity mismatch
- [x] Handle error returns (for example if `store_messages_for_folder` returns an error we could still try to do the `flag_updates`)
- [x] Notify the model that it needs to update